### PR TITLE
Don't "teleport" to pokestops when activating them

### DIFF
--- a/app/scripts/map.js
+++ b/app/scripts/map.js
@@ -108,7 +108,7 @@ Map.prototype.addCatch = function(pt) {
             pt.lat = pos.lat;
             pt.lng = pos.lng;
         } else {
-            // no position to pin to, abord
+            // no position to pin to, abort
             return;
         }
     }
@@ -125,9 +125,8 @@ Map.prototype.addCatch = function(pt) {
 Map.prototype.addVisitedPokestop = function(pt) {
     if (!pt.lat) return;
 
-    console.log("Pokestop.");
+    console.log("Pokestop visited.");
 
-    this.addToPath(pt);
     this.pokestops.push(pt);
 
     var ps = this.availablePokestops.find(ps => ps.id == pt.id);


### PR DESCRIPTION
The visualizer should represent the actual bot movement. The bot won't really go to the pokestop coordinates, so they shouldn't be added to the path.

This will partly fix #8  
