### PR TITLE
fix npm package.json parsing error

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "gulp-concat": "^2.6.0",
     "gulp-cssnano": "^2.1.2",
     "gulp-rename": "^1.2.2",
-    "gulp-uglify": "^1.5.4",
+    "gulp-uglify": "^1.5.4"
   },
   "build": {
     "appId": "nico.NecrobotVisualizer",


### PR DESCRIPTION
got the following npm error when i want to "npm start":

npm-debug.log excerpt:

> 6 error Windows_NT 6.3.9600
> 7 error argv "C:\Dev\nodejs\node.exe" "C:\path\AppData\Roaming\npm\node_modules\npm\bin\npm-cli.js" "start"
> 8 error node v4.4.7
> 9 error npm  v3.10.5
> 10 error file C:\path\necrobotvisualizer\package.json
> 11 error code EJSONPARSE
> 12 error Failed to parse json
> 12 error Trailing comma in object at 21:3
> 12 error   },
> 12 error   ^
> 13 error File: C:\path\necrobotvisualizer\package.json
> 14 error Failed to parse package.json data.
> 14 error package.json must be actual JSON, not just JavaScript.
> 14 error
> 14 error This is not a bug in npm.
> 14 error Tell the package author to fix their package.json file. JSON.parse
