### PR TITLE
Fixed marker anchoring

### DIFF
--- a/app/assets/css/app.css
+++ b/app/assets/css/app.css
@@ -38,8 +38,6 @@ body, html, .content {
 }
 
 .pkmIcon {
-  max-height: 45px;
-  max-width: 60px;
 }
 
 .toolbar {

--- a/app/package.json
+++ b/app/package.json
@@ -5,6 +5,7 @@
   "author": "Nicolas Schmitt",
   "main": "main.js",
   "dependencies": {
-    "electron-squirrel-startup": "^1.0.0"
+    "electron-squirrel-startup": "^1.0.0",
+    "image-size": "latest"
   }
 }

--- a/app/scripts/map.js
+++ b/app/scripts/map.js
@@ -109,7 +109,18 @@ Map.prototype.addCatch = function(pt) {
 
     this.catches.push(pt);
 
-    var icon = L.icon({ iconUrl: `./assets/pokemon/${pt.id}.png`, className: "pkmIcon", iconAnchor: [25, 25] });
+    var iconUrl = `/assets/pokemon/${pt.id}.png`;
+    var urlForL = '.' + iconUrl;
+    var urlForSizeOf = './app/' + iconUrl;
+
+    var sizeOf = require('image-size');
+    var imageDimensions = sizeOf(urlForSizeOf);
+    var maxDimension = Math.max(imageDimensions.width, imageDimensions.height);
+    var maxSize = 50;
+    var scaleFactor = maxSize / maxDimension;
+    var iconSize =  [imageDimensions.width*scaleFactor, imageDimensions.height*scaleFactor]
+    
+    var icon = L.icon({ iconUrl: urlForL, className: "pkmIcon", iconSize: iconSize });
     L.marker([pt.lat, pt.lng], {icon: icon, zIndexOffset: 100 }).bindPopup(pkm).addTo(this.layerCatches);
 }
 


### PR DESCRIPTION
Fix for #74: fixed marker anchoring, fixed weird scaling, moved icon scaling from css to javascript.

Now anchors properly:
![image](https://cloud.githubusercontent.com/assets/7861188/17346395/1565ce94-5913-11e6-82b2-19b082623d1c.png)

![image](https://cloud.githubusercontent.com/assets/7861188/17346416/319e36aa-5913-11e6-9f52-c06c2b5a2839.png)

Added a node package for image size calculation, so you'll need to `npm install` again. Also, since this is my first time ever developing for node.js, I might have fucked up something with package requiring. It may need to be in a different place like some global requires file - please fix it if I did it in a wrong place.

Lastly, if someone could tell me why the package doesn't use `app` as the current direcrory, that would be great. I had to append `./app/` manually, which seems kind of like a hack. Would be nice if someone figured that out.
