### PR TITLE
Fixed toastr js/css upstream locations

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
     <link rel="stylesheet" href="https://npmcdn.com/leaflet@1.0.0-rc.2/dist/leaflet.css" />
-    <link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/css/toastr.min.css" />
+    <link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.css" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/vex-js/2.3.4/css/vex.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/vex-js/2.3.4/css/vex-theme-default.min.css">
     <!--<link rel="stylesheet" href="lib/lib.full.min.css">-->
@@ -16,7 +16,7 @@
     <script>if (typeof module === 'object') {window.module = module; module = undefined;}</script>
     <script src="https://code.jquery.com/jquery-3.1.0.min.js"></script>
     <script src="https://npmcdn.com/leaflet@1.0.0-rc.2/dist/leaflet.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/js/toastr.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/vex-js/2.3.4/js/vex.combined.min.js"></script>
     <script>vex.defaultOptions.className = 'vex-theme-default';</script>
     <!--<script src="lib/lib.full.min.js"></script>-->


### PR DESCRIPTION
Related to #53 and potentially #83 if you check https://cdnjs.com/libraries/toastr.js/latest# the actual links provided there for both the toastr.min.js and toastr.min.css are under: http://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/ with no /js/ or /css/ suffixed URI.

https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/js/toastr.min.js and http://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/css/toastr.min.css both 404.
